### PR TITLE
Can not import int_class, so I changed that part to int.

### DIFF
--- a/utils/collate.py
+++ b/utils/collate.py
@@ -5,7 +5,7 @@ Licensed under the CC BY-NC 4.0 license (https://creativecommons.org/licenses/by
 import torch
 import numpy as np
 import collections
-from torch._six import string_classes, int_classes
+from torch._six import string_classes
 
 
 """ Custom collate function """
@@ -19,7 +19,7 @@ def collate_custom(batch):
     elif isinstance(batch[0], np.ndarray):
         return np.stack(batch, 0)
 
-    elif isinstance(batch[0], int_classes):
+    elif isinstance(batch[0], int):
         return torch.LongTensor(batch)
 
     elif isinstance(batch[0], float):


### PR DESCRIPTION
When I try to run simclr.py, I got an error that "ImportError: cannot import name 'int_classes' from 'torch." at utils/collate.py

I searched about that, and the below page says "just set int_classes = int instead of importing it from _six"
https://discuss.pytorch.org/t/cannot-import-name-int-classes-from-torch-six/126611

Thus, I changed that.